### PR TITLE
README.md: oe-init-build-en -> oe-init-build-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Obtain keys for image signing
 
 Build development SD image
 --------------------------
-	source ./oe-init-build-en
+	source ./oe-init-build-env
 	bitbake sla-image-dev # other targets are sla-update-bundle, sla-bootstrap
 
 Write the image to the SD card


### PR DESCRIPTION
README.md instructions for building development SD image had "oe-init-build-en" instead of "oe-init-build-env". Not a big issue, but it took me a couple minutes to figure out what was wrong.